### PR TITLE
Fixing call to action label

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
               <h2>State of the art models</h2>
               <p>AllenNLP includes reference implementations of high quality models for both core NLP problems (e.g. semantic role labeling) and NLP applications (e.g. textual entailment).</p>
               <p>
-                <br><a href="/models">View Metrics</a></p>
+                <br><a href="/models">View Models</a></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8367927/31638604-6ab69678-b289-11e7-9ee4-c4e073d9ad2b.png)

There's no longer a `Metrics` page. We're calling it `Models` now, so the call to action should probably reflect that.

Also, this is a test PR to make sure I have my local and remote GIT setup correctly. :)