### PR TITLE
Change 'Publications' to 'Featured Publications'.

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -12,8 +12,9 @@
       <div class="banner banner--interior-hero">
         <div class="constrained constrained--sm">
           <div class="banner--interior-hero__content">
-            <h1>Publications</h1>
-            <p class="t-sm">A core goal of the AllenNLP team is to push the field of natural language processing forward through cutting-edge research. See the publications from our team.</p>
+            <h1>Featured Publications</h1>
+            <p class="t-sm">A core goal of the AllenNLP team is to push the field of natural language processing forward through cutting-edge research.  Below is a list of our featured publications.</p>
+            <p class="t-sm">For our full list of publications, please visit <a href="http://allenai.org/papers/index.html#allen-nlp">the AI2 Publications page for AllenNLP</a>.</p>
           </div>
         </div>
       </div>
@@ -22,9 +23,12 @@
           <li><a href="http://www.allennlp.org/papers/AllenNLP_white_paper.pdf" target="_blank" class="publications__title">AllenNLP: A Deep Semantic Natural Language Processing Platform</a><span class="publications__authors">Matt Gardner, Joel Grus, Mark Neumann, Oyvind Tafjord, Pradeep Dasigi, Nelson Liu, Matthew Peters, Michael Schmitz, Luke Zettlemoyer</span><span class="publications__year">2017</span>
             <p class="publications__abstract">This paper describes AllenNLP, a platform for research on deep learning methods in natural language understanding. AllenNLP is designed to support researchers who want to build novel language understanding models quickly and easily. It is built on top of PyTorch, allowing for dynamic computation graphs, and provides (1) a flexible data API that handles intelligent batching and padding, (2) highlevel abstractions for common operations...</p>
           </li>
+          <li><a href="https://arxiv.org/abs/1802.05365" target="_blank" class="publications__title">Deep contextualized word representations</a><span class="publications__authors">Matthew E. Peters, Mark Neumann, Mohit Iyyer, Matt Gardner, Christopher Clark, Kenton Lee, Luke Zettlemoyer.</span><span class="publications__year">NAACL 2018</span>
+            <p class="publications__abstract">We introduce a new type of deep contextualized word representation that models both (1) complex characteristics of word use (e.g., syntax and semantics), and (2) how these uses vary across linguistic contexts (i.e., to model polysemy). Our word vectors are learned functions of the internal states of a deep bidirectional language model (biLM), which is pre-trained on a large text corpus. We show that these representations can be easily added to existing models and significantly improve the state of the art across six challenging NLP problems, including question answering, textual entailment and sentiment analysis. We also present an analysis showing that exposing the deep internals of the pre-trained network is crucial, allowing downstream models to mix different types of semi-supervision signals.
+</p>
+          </li>
           <li><a href="https://arxiv.org/abs/1802.05365" target="_blank" class="publications__title">Deep Contextualized Word Representations</a><span class="publications__authors">Matthew E. Peters, Mark Neumann, Mohit Iyyer, Matt Gardner, Christopher Clark, Kenton Lee, Luke Zettlemoyer</span><span class="publications__year">2018</span>
             <p class="publications__abstract">We introduce a new type of deep contextualized word representation that models both (1) complex characteristics of word use (e.g., syntax and semantics), and (2) how these uses vary across linguistic contexts (i.e., to model polysemy). Our word vectors are learned functions of the internal states of a deep bidirectional language model (biLM), which is pre-trained on a large text corpus. We show that these representations can be easily added to existing models and significantly improve the state of the art across six challenging NLP problems, including question answering, textual entailment and sentiment analysis. We also present an analysis showing that exposing the deep internals of the pre-trained network is crucial, allowing downstream models to mix different types of semi-supervision signals.</p>
-          </li>
           <li><a href="https://homes.cs.washington.edu/~luheng/files/acl2017_hllz.pdf" target="_blank" class="publications__title">Deep Semantic Role Labeling: What Works and What’s Next</a><span class="publications__authors">Luheng He, Kenton Lee, Mike Lewis, Luke Zettlemoyer</span><span class="publications__year">2017</span>
             <p class="publications__abstract">We introduce a new deep learning model for semantic role labeling (SRL) that significantly improves the state of the art, along with detailed analyses to reveal its strengths and limitations. We use a deep highway BiLSTM architecture with constrained decoding, while observing a number of recent best practices for initialization and regularization. Our 8-layer ensemble model achieves 83.2 F1 on the CoNLL 2005 test set and 83.4 F1 on...</p>
           </li>


### PR DESCRIPTION
I just added the ELMo papers and changed the title to "Featured Publications".

It's been bothering me that this list is out of date since it advertises itself as a comprehensive list. I don't want to manage a complete list of publications on the AllenNLP website.

This change removes the expectation that this page is an exhaustive list of publications.  When we have impactful publications the author can add them to this site.  If, for any reason, we want to remove some of the current publications in the list, feel free to do so.
