### PR TITLE
Add prediction and demo tutorial

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -51,6 +51,11 @@
                   Using AllenNLP in Your Project
                 </a>
               </li>
+              <li>
+                <a href="https://github.com/allenai/allennlp/blob/v0.4.2/tutorials/getting_started/making_predictions_and_creating_a_demo.md">
+                  Making Predictions and Creating a Demo
+                </a>
+              </li>
             </ul>
             <h2>Deeper Dives</h2>
             <ul>


### PR DESCRIPTION
This tutorial was missing from our list.  What do you think about renaming this and "Using AllenNLP in your Project" to something like:

* Using AllenNLP as a Library (Part 1) -- Datasets and Models
* Using AllenNLP as a Library (Part 2) -- Predictions and Demos

It took me a while to figure out that they were related.