### PR TITLE
Adding Terms and Conditions link to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,12 +6,14 @@
           <use xlink:href="#icon__ai2-logo-full"></use>
         </svg>
       </a>
-      <p><span>Proudly built by <a href="http://allenai.org/" target="_blank">AI2</a>.</span></p>
+
       <p class="footer__content__copyright">
         <span>
           &copy; The Allen Institute for Artificial Intelligence - All Rights Reserved.
-          |
+          <br />
           <a href="https://allenai.org/privacy-policy.html">Privacy Policy</a>
+          &nbsp;|&nbsp;
+          <a href="https://allenai.org/terms.html">Terms and Conditions</a>
         </span>
       </p>
     </div>


### PR DESCRIPTION
**This PR:**

- Adds Terms link to footer
- Removes "Proudly built by" label, as it was crowding the footer and seemed redundant. That label was a relic from before we elevated AI2 brand prominence throughout the AllenNLP site.

![image](https://user-images.githubusercontent.com/8367927/44933410-d391ba80-ad1d-11e8-9c5c-4ae08f7a5109.png)

Fixes [Add Terms / Privacy Policy links to footer (#62)](https://github.com/allenai/allennlp-website/issues/62)