### PR TITLE
Fixing prediction and evaluation spacing on Models page

### DIFF
--- a/models.html
+++ b/models.html
@@ -121,14 +121,15 @@
                       <div data-tab="prediction" class="tab__page">
                         <div class="tab__page__content">
                           <pre><code class="no-highlight">echo '{"passage": "A reusable launch system (RLS, or reusable launch vehicle, RLV) is a launch system which is capable of launching a payload into space more than once. This contrasts with expendable launch systems, where each launch vehicle is launched once and then discarded. No completely reusable orbital launch system has ever been created. Two partially reusable launch systems were developed, the Space Shuttle and Falcon 9. The Space Shuttle was partially reusable: the orbiter (which included the Space Shuttle main engines and the Orbital Maneuvering System engines), and the two solid rocket boosters were reused after several months of refitting work for each launch. The external tank was discarded after each flight.", "question": "How many partially reusable launch systems were developed?"}' > mc-examples.jsonl
-      allennlp predict \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz \
-          mc-examples.jsonl</code></pre></div>
+allennlp predict \
+    https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz \
+    mc-examples.jsonl</code></pre>
+                        </div>
                       </div>
                       <div data-tab="evaluation" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">allennlp evaluate \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz \
-          https://s3-us-west-2.amazonaws.com/allennlp/datasets/squad/squad-dev-v1.1.json</code></pre>
+    https://s3-us-west-2.amazonaws.com/allennlp/models/bidaf-model-2017.09.15-charpad.tar.gz \
+    https://s3-us-west-2.amazonaws.com/allennlp/datasets/squad/squad-dev-v1.1.json</code></pre>
                         </div>
                       </div>
                       <div data-tab="training" class="tab__page">
@@ -182,14 +183,15 @@
                     <div class="tab__page-container">
                       <div data-tab="prediction" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">echo '{"hypothesis": "Two women are sitting on a blanket near some rocks talking about politics.", "premise": "Two women are wandering along the shore drinking iced tea."}' > te-examples.jsonl
-      allennlp predict \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-elmo-2018.02.19.tar.gz \
-          te-examples.jsonl</code></pre></div>
+allennlp predict \
+    https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-elmo-2018.02.19.tar.gz \
+    te-examples.jsonl</code></pre>
+                        </div>
                       </div>
                       <div data-tab="evaluation" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">allennlp evaluate \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-elmo-2018.02.19.tar.gz \
-          https://s3-us-west-2.amazonaws.com/allennlp/datasets/snli/snli_1.0_test.jsonl</code></pre></div>
+    https://s3-us-west-2.amazonaws.com/allennlp/models/decomposable-attention-elmo-2018.02.19.tar.gz \
+    https://s3-us-west-2.amazonaws.com/allennlp/datasets/snli/snli_1.0_test.jsonl</code></pre></div>
                       </div>
                       <div data-tab="training" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">allennlp train training_config/decomposable_attention.json -s output_path</code></pre></div>
@@ -244,9 +246,10 @@
                     <div class="tab__page-container">
                       <div data-tab="prediction" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">echo '{"sentence": "Did Uriah honestly think he could beat the game in under three hours?"}' > srl-examples.jsonl
-      allennlp predict \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2018.05.25.tar.gz \
-          srl-examples.jsonl</code></pre></div>
+allennlp predict \
+    https://s3-us-west-2.amazonaws.com/allennlp/models/srl-model-2018.05.25.tar.gz \
+    srl-examples.jsonl</code></pre>
+                        </div>
                       </div>
                       <div data-tab="evaluation" class="tab__page">
                         <div class="tab__page__content">
@@ -308,9 +311,10 @@
                     <div class="tab__page-container">
                       <div data-tab="prediction" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">echo '{"document": "The woman reading a newspaper sat on the bench with her dog."}' > coref-examples.jsonl
-      allennlp predict \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2018.02.05.tar.gz \
-          coref-examples.jsonl</code></pre></div>
+allennlp predict \
+    https://s3-us-west-2.amazonaws.com/allennlp/models/coref-model-2018.02.05.tar.gz \
+    coref-examples.jsonl</code></pre>
+                        </div>
                       </div>
                       <div data-tab="evaluation" class="tab__page">
                         <div class="tab__page__content">
@@ -370,9 +374,10 @@
                     <div class="tab__page-container">
                       <div data-tab="prediction" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">echo '{"sentence": "Did Uriah honestly think he could beat The Legend of Zelda in under three hours?"}' > ner-examples.jsonl
-      allennlp predict \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2018.04.26.tar.gz \
-          ner-examples.jsonl</code></pre></div>
+allennlp predict \
+    https://s3-us-west-2.amazonaws.com/allennlp/models/ner-model-2018.04.26.tar.gz \
+    ner-examples.jsonl</code></pre>
+                        </div>
                       </div>
                       <div data-tab="evaluation" class="tab__page">
                         <div class="tab__page__content">
@@ -434,9 +439,10 @@
                     <div class="tab__page-container">
                       <div data-tab="prediction" class="tab__page">
                         <div class="tab__page__content"><pre><code class="no-highlight">echo '{"sentence": "If I bring 10 dollars tomorrow, can you buy me lunch?"}' > cparse-examples.jsonl
-      allennlp predict \
-          https://s3-us-west-2.amazonaws.com/allennlp/models/elmo-constituency-parser-2018.03.14.tar.gz \
-          cparse-examples.jsonl</code></pre></div>
+allennlp predict \
+    https://s3-us-west-2.amazonaws.com/allennlp/models/elmo-constituency-parser-2018.03.14.tar.gz \
+    cparse-examples.jsonl</code></pre>
+                        </div>
                       </div>
                       <div data-tab="evaluation" class="tab__page">
                         <div class="tab__page__content">


### PR DESCRIPTION
Fixes [Spacing is off on the prediction entries on the website (#67)](https://github.com/allenai/allennlp-website/issues/67)

---

![image](https://user-images.githubusercontent.com/8367927/44934078-5e73b480-ad20-11e8-97fd-ac8d24f039b7.png)
