### PR TITLE
Add DialogQA model (from QUAC paper) to the gallery

### DIFF
--- a/_data/gallery.yml
+++ b/_data/gallery.yml
@@ -35,3 +35,12 @@
   - code:   "https://github.com/allenai/allennlp/pull/1594"
 
 ###############################################################################
+
+- title:    "Question Answering in Context"
+  authors:  "Eunsol Choi, He He, Mohit Iyyer, Mark Yatskar, Wen-tau Yih, Yejin Choi, Percy Liang, Luke Zettlemoyer"
+  venue:    "EMNLP 2018"
+  links:
+  - paper:  "https://www.semanticscholar.org/paper/QuAC-%3A-Question-Answering-in-Context-Choi-He/901abeeb03a0652fff6f41e1018d80dcf76a82bb"
+  - code:   "https://github.com/allenai/allennlp/blob/master/allennlp/models/reading_comprehension/dialog_qa.py"
+
+###############################################################################


### PR DESCRIPTION
@eunsol FYI.  Because there's no trained model that runs on the code currently in master, I couldn't put this as a model above, with the example commands to run stuff.  If you can provide us with a trained model that we can host somewhere, I can move this up to the other section.