### PR TITLE
Fix type annotation for .forward() in tutorial

### DIFF
--- a/_includes/default-tutorial.html
+++ b/_includes/default-tutorial.html
@@ -186,7 +186,7 @@ class LstmTagger(Model):
 {% highlight python %}
     def forward(self,
                 sentence: Dict[str, torch.Tensor],
-                labels: torch.Tensor = None) -> torch.Tensor:
+                labels: torch.Tensor = None) -> Dict[str, torch.Tensor]:
 {% endhighlight %}
 </div>
 <div class="annotated-code__code-block" id="c26">


### PR DESCRIPTION
c.f. https://github.com/allenai/allennlp/pull/2122.  Does this one get deployed automatically, or do we need to push a button somewhere for the website, too?