### PR TITLE
Add PubMed ELMo to Contributed Models

### DIFF
--- a/elmo.html
+++ b/elmo.html
@@ -103,8 +103,7 @@ The ELMo 5.5B model was trained on a dataset of 5.5B tokens consisting of Wikipe
 In tasks where we have made a direct comparison, the 5.5B model has slightly higher performance then the original ELMo model, so we recommend it as a default model.
 </p>
     <h1>Contributed ELMo Models</h1>
-    ELMo models have been contributed for other languages.  We maintain a list of contributed models
-    here but are unable to respond to quality issues ourselves.
+    ELMo models have been trained for other languages and domains. We maintain a list of models here but are unable to respond to quality issues ourselves.
     <table>
       <tr style="border-bottom: 2px solid black;">
         <td style="border-right: 1px solid black;"><b>Model</b></td>
@@ -119,6 +118,13 @@ In tasks where we have made a direct comparison, the 5.5B model has slightly hig
         <td>Federal University of Goiás (UFG). Pedro Vitor Quinta de Castro, Anderson da Silva
           Soares, Nádia Félix Felipe da Silva, Rafael Teixeira Sousa, Ayrton Denner da Silva Amaral.
           Sponsered by Data-H, Aviso Urgente, and Americas Health Labs.
+        </td>
+      </tr>
+      <tr>
+        <td style="border-right: 1px solid black;">PubMed</td>
+        <td><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_PubMed_sentences_large_5epochs.hdf5">weights<a/></td>
+        <td style="border-right: 2px solid black;"><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_options.json">options<a/></td>
+        <td>Matthew Peters
         </td>
       </tr>
     </table>

--- a/elmo.html
+++ b/elmo.html
@@ -122,7 +122,7 @@ In tasks where we have made a direct comparison, the 5.5B model has slightly hig
       </tr>
       <tr>
         <td style="border-right: 1px solid black;">PubMed</td>
-        <td><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_PubMed_sentences_large_5epochs.hdf5">weights<a/></td>
+        <td><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_weights_PubMed_only.hdf5">weights<a/></td>
         <td style="border-right: 2px solid black;"><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pubmed/elmo_2x4096_512_2048cnn_2xhighway_options.json">options<a/></td>
         <td>Matthew Peters
         </td>


### PR DESCRIPTION
Resolves issue #118. 
Should we add any specifics about the PubMed corpus these were trained on (e.g. a link to the corpus / details about its scope)? 
Also probably want to add AI2 affiliation for @matt-peters but not sure how to stylize it / whether to put before or after name. 