### PR TITLE
Fixing DROP paper link

### DIFF
--- a/drop.html
+++ b/drop.html
@@ -34,7 +34,7 @@
         below.
         </p>
 
-        <li><a href="https://www.semanticscholar.org/paper/9498f5b9ff0052c22e41979df49bc8efca0a9d17", target="_blank">Paper</a>, describing the dataset and our initial model for it,
+        <li><a href="https://www.semanticscholar.org/paper/DROP%3A-A-Reading-Comprehension-Benchmark-Requiring-Dua-Wang/248352852f5baa2ef333077c6084a618cb1ea0fd", target="_blank">Paper</a>, describing the dataset and our initial model for it,
           Numerically-Augmented QANet (NAQANet), that adds some rudimentary numerical reasoning capability on top of
           <a href="https://www.semanticscholar.org/paper/QANet%3A-Combining-Local-Convolution-with-Global-for-Yu-Dohan/8c1b00128e74f1cd92aede3959690615695d5101">QANet</a>.</li>
         <li><a href="https://s3-us-west-2.amazonaws.com/allennlp/datasets/drop/drop_dataset.zip">Data</a>, with about 77k questions in the


### PR DESCRIPTION
The link to the DROP paper on S2 got broken somehow. This fixes the link.