### PR TITLE
Updating org name reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       <div class="banner banner--padded c-bg-slate t-white t-center">
         <div class="constrained constrained--narrow">
           <h2>Proudly built by <a href="http://allenai.org/" target="_blank" class="banner__ai2-logo"><svg><use xlink:href="#icon__ai2-logo"></use></svg></a><span class="u-hidden">AI2</span></h2>
-          <p><span class="t-sm">AllenNLP is built and maintained by the Allen Institute for Artificial Intelligence, in close collaboration with researchers at the University of Washington and elsewhere. With a dedicated team of best-in-field researchers and software engineers, the AllenNLP project is uniquely positioned for long-term growth alongside a vibrant open-source development community.</span></p>
+          <p><span class="t-sm">AllenNLP is built and maintained by the Allen Institute for AI, in close collaboration with researchers at the University of Washington and elsewhere. With a dedicated team of best-in-field researchers and software engineers, the AllenNLP project is uniquely positioned for long-term growth alongside a vibrant open-source development community.</span></p>
         </div>
       </div>
 


### PR DESCRIPTION
**`Allen Institute for Artificial Intelligence`** -> **`Allen Institute for AI`**

Oren has requested that we be consistent throughout our web properties when referencing our org name. We are currently dba `Allen Institute for AI`.

Note that this PR intentionally ***does not*** change references to our legal name in legal copy (e.g. licenses and copyright footer text), as the legal name has not changed--only how we're branding ourselves.