### PR TITLE
Portuguese ELMo models update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 .sass-cache
+.idea/

--- a/elmo.html
+++ b/elmo.html
@@ -112,13 +112,18 @@ In tasks where we have made a direct comparison, the 5.5B model has slightly hig
         <td><b>Contributor/Notes</td>
       </tr>
       <tr>
-        <td style="border-right: 1px solid black;">Portuguese</td>
-        <td><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/elmo_pt_weights.hdf5">weights<a/></td>
-        <td style="border-right: 2px solid black;"><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/elmo_pt_options.json">options<a/></td>
-        <td>Federal University of Goiás (UFG). Pedro Vitor Quinta de Castro, Anderson da Silva
+        <td style="border-right: 1px solid black;">Portuguese (Wikipedia corpus)</td>
+        <td><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/wikipedia/elmo_pt_weights.hdf5">weights<a/></td>
+        <td style="border-right: 2px solid black;"><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/wikipedia/options.json">options<a/></td>
+        <td rowspan="2">Federal University of Goiás (UFG). Pedro Vitor Quinta de Castro, Anderson da Silva
           Soares, Nádia Félix Felipe da Silva, Rafael Teixeira Sousa, Ayrton Denner da Silva Amaral.
           Sponsered by Data-H, Aviso Urgente, and Americas Health Labs.
         </td>
+      </tr>
+      <tr>
+        <td style="border-right: 1px solid black;">Portuguese (brWaC corpus)</td>
+        <td><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/brwac/elmo_pt_weights_dgx1.hdf5">weights<a/></td>
+        <td style="border-right: 2px solid black;"><a href="https://s3-us-west-2.amazonaws.com/allennlp/models/elmo/contributed/pt/brwac/options.json">options<a/></td>
       </tr>
       <tr>
         <td style="border-right: 1px solid black;">Japanese</td>


### PR DESCRIPTION
Updating the Portuguese models for ELMo, adding one for Wikipedia and another for brWaC corpus.